### PR TITLE
Add Makefile to setup venv and run the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+VENV_NAME ?= venv
+APP ?= Polling.py
+
+PYTHON := $(VENV_NAME)/bin/python3
+PIP := $(VENV_NAME)/bin/pip
+ACTIVATE := $(VENV_NAME)/bin/activate
+
+.PHONY: install update clean run
+
+virtual: $(PIP) $(ACTIVATE)
+
+requirements: requirements.txt $(PIP)
+	$(PIP) --require-virtualenv install -Ur $<
+
+install: install.py $(ACTIVATE) | requirements
+	( source $(ACTIVATE); $(PYTHON) install.py; )
+
+update: update.py $(ACTIVATE) | requirements
+	( source $(ACTIVATE); $(PYTHON) update.py; )
+
+run: $(APP) $(ACTIVATE) | requirements
+	( source $(ACTIVATE); $(PYTHON) $(APP); )
+
+clean:
+	rm -Rf $(VENV_NAME)
+
+$(VENV_NAME):
+	virtualenv -p /usr/bin/python3 $(VENV_NAME)
+
+$(PIP) $(ACTIVATE): $(VENV_NAME)

--- a/README.md
+++ b/README.md
@@ -47,3 +47,12 @@ source env/bin/activate
 pip install -r requirements.txt
 python Polling.py
 ```
+
+On Linux, you can also use `make` to install/update the requirement and run the project:
+```bash
+# install or update requirements only:
+make requirements
+
+# installs or updates the requirements and runs the project:
+make run
+```


### PR DESCRIPTION
Following up PR 22, I had this Makefile lingering which I use to setup and run Python projects in a venv.

Take note that it also offers an install and update target which can be used to run an installer and updater if providing the necessary Python files. There are currently no such files so both targets `make install` and `make update` will just complain about the missing files.

Link: https://github.com/cakama3a/Polling/pull/22