### PR TITLE
Fix error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can run the Python file after installing requirements with:
 python -m venv env
 source env/bin/activate
 pip install -r requirements.txt
-python Polling.py
+python Python.py
 ```
 
 ## Donation


### PR DESCRIPTION
Update python filename in the README instructions.  Looks like the file was renamed in     9526481d6741797c36ae86e36bacd24cce9f8e71 but the Python instructions were not updated